### PR TITLE
WIP update to latest atom core APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/lib/todo-list-view.coffee
+++ b/lib/todo-list-view.coffee
@@ -1,4 +1,5 @@
-{$, ScrollView} = require 'atom'
+
+{$, ScrollView} = require 'atom-space-pen-views'
 
 module.exports =
 class TodoListView extends ScrollView
@@ -9,10 +10,13 @@ class TodoListView extends ScrollView
       @div class: 'todo-list-resize-handle', outlet: 'resizeHandle'
 
   initialize: (serializeState) ->
-    atom.workspaceView.command 'todo-list:toggle', => @toggle()
-    atom.workspaceView.command 'todo-list:toggle-side', => @toggleSide()
+    super
+    atom.commands.add 'atom.workspace', 'todo-list:toggle', (e) => @toggle()
+    atom.commands.add 'atom-workspace', 'todo-list:toggle-side', (e) => @toggleSide()
     @on 'mousedown', '.todo-list-resize-handle', (e) => @resizeStarted(e)
     @on 'core:close core:cancel', => @detach()
+
+    # @TODO this subscribe API is no longer functional
     @subscribe atom.config.observe 'todo-list.showOnRightSide', callNow: false, (newValue) =>
       @detach()
       @attach()
@@ -131,6 +135,7 @@ class TodoListView extends ScrollView
     # Now update all the messages.
     @createReminderList()
 
+  # @TODO atom.config.toggle no longer works
   toggleSide: ->
     atom.config.toggle('todo-list.showOnRightSide')
 
@@ -151,11 +156,11 @@ class TodoListView extends ScrollView
     if atom.config.get('todo-list.showOnRightSide')
       @element.classList.remove('panel-left')
       @element.classList.add('panel-right')
-      atom.workspaceView.appendToRight(this)
+      atom.workspace.addRightPanel(item: this)
     else
       @element.classList.remove('panel-right')
       @element.classList.add('panel-left')
-      atom.workspaceView.appendToLeft(this)
+      atom.workspace.addLeftPanel(item: this)
 
   toggle: ->
     if @hasParent()

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   "repository": "https://github.com/AnthonyCalandra/todo-list",
   "license": "MIT",
   "engines": {
-    "atom": ">0.50.0"
+    "atom": ">=1.0.0 <2.0.0"
   },
-  "dependencies": {}
+  "dependencies": {
+    "atom-space-pen-views": "^2.0.0"
+  }
 }

--- a/spec/todo-list-spec.coffee
+++ b/spec/todo-list-spec.coffee
@@ -1,4 +1,3 @@
-{WorkspaceView} = require 'atom'
 TodoList = require '../lib/todo-list'
 
 # Use the command `window:run-package-specs` (cmd-alt-ctrl-p) to run specs.
@@ -7,24 +6,25 @@ TodoList = require '../lib/todo-list'
 # or `fdescribe`). Remove the `f` to unfocus the block.
 
 describe "TodoList", ->
-  activationPromise = null
+  [workspaceElement, activationPromise] = []
 
   beforeEach ->
-    atom.workspaceView = new WorkspaceView
+    workspaceElement = atom.views.getView(atom.workspace)
     activationPromise = atom.packages.activatePackage('todo-list')
 
   describe "when the todo-list:toggle event is triggered", ->
     it "attaches and then detaches the view", ->
-      expect(atom.workspaceView.find('.todo-list')).not.toExist()
+      jasmine.attachToDOM(workspaceElement)
+      expect(workspaceElement.querySelector('.todo-list')).not.toExist()
 
       # This is an activation event, triggering it will cause the package to be
       # activated.
-      atom.workspaceView.trigger 'todo-list:toggle'
+      atom.commands.dispatch workspaceElement, 'todo-list:toggle'
 
       waitsForPromise ->
         activationPromise
 
       runs ->
-        expect(atom.workspaceView.find('.todo-list')).toExist()
-        atom.workspaceView.trigger 'todo-list:toggle'
-        expect(atom.workspaceView.find('.todo-list')).not.toExist()
+        expect(workspaceElement.querySelector('.todo-list')).toExist()
+        atom.commands.dispatch workspaceElement, 'todo-list:toggle'
+        expect(workspaceElement.querySelector('.todo-list')).not.toExist()


### PR DESCRIPTION
:beetle: :construction:

Took an attempt at fixing the issues that break the todo-list package from loading in atom. It turns out a good majority of the underlying APIs that this package rely on have been deprecated. If you comment out
the 2 remaining `@todo` sections, you can get the package to load in atom but it’s still not functional. Wanted to check-in my work so someone else might be able to take it the last mile.

I’m switching to using [imdone-atom](https://atom.io/packages/imdone-atom) instead of this package because it’s more feature rich anyway but I like the minimalism this package has taken.
